### PR TITLE
Use a static property to implement singleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,7 @@ if !authToken.isEmpty {
 ```
 class DB : SwiftStore {
     /* Shared Instance */
-    struct Static {
-        static var onceToken: dispatch_once_t = 0
-        static var instance: DB? = nil
-    }
-    
-    class var store:DB {
-        dispatch_once(&Static.onceToken) {
-            Static.instance = DB()
-        }
-        return Static.instance!
-    }
+    static let store = DB()
     
     init() {
         super.init(storeName: "db")


### PR DESCRIPTION
Swift supports static properties in classes, and they are instantiated lazily like any other global variable.
It actually uses dispatch_once under the hood, but that's an implementation detail.